### PR TITLE
Add time-aware NodeState with forgetting score and tests

### DIFF
--- a/src/dialograph/core/node.py
+++ b/src/dialograph/core/node.py
@@ -1,12 +1,68 @@
+import time
+import math
 
 
 class NodeState:
     """
-    Docstring for NodeState
+    Represents a node in the Dialograph with:
+    - time-aware confidence decay
+    - explicit forgetting score
+    - optional persistence (never decays / never forgotten)
     """
 
-    def __init__(self):
-        pass 
+    node_type: str
+    data: dict
+    confidence: float
+    forgetting_score: float
+    created_at: float
+    last_accessed: float
+    persistent: bool
 
-    def decay(self):
-        pass
+    def __init__(
+        self,
+        node_type: str,
+        data: dict | None = None,
+        confidence: float = 1.0,
+        created_at: float | None = None,
+        last_accessed: float | None = None,
+        persistent: bool = False,
+    ):
+        self.node_type = node_type
+        self.data = data or {}
+        self.confidence = confidence
+        self.created_at = created_at or time.time()
+        self.last_accessed = last_accessed or time.time()
+        self.persistent = persistent
+
+        # initialize forgetting score
+        self.forgetting_score = self._compute_forgetting_score()
+
+    def _compute_forgetting_score(self) -> float:
+        """Internal helper to compute forgetting score."""
+        if self.persistent:
+            return math.inf
+        confidence_clamped = max(0.0, min(1.0, self.confidence))
+        return 1.0 - confidence_clamped
+
+    def decay(self, decay_rate_per_second: float = 0.0001) -> float:
+        """
+        Time-aware exponential confidence decay.
+
+        Args:
+            decay_rate_per_second (float): fraction of confidence lost per second
+
+        Returns:
+            float: Updated confidence
+        """
+        if self.persistent:
+            return self.confidence
+
+        now = time.time()
+        elapsed = now - self.last_accessed
+
+        self.confidence *= (1.0 - decay_rate_per_second) ** elapsed
+        self.last_accessed = now
+
+        # keep forgetting score in sync
+        self.forgetting_score = self._compute_forgetting_score()
+        return self.confidence

--- a/tests/test_node_state.py
+++ b/tests/test_node_state.py
@@ -1,0 +1,69 @@
+import time
+import math
+import pytest
+
+from dialograph.core.node import NodeState
+
+
+def test_initial_forgetting_score():
+    node = NodeState(node_type="belief", confidence=1.0)
+    assert node.forgetting_score == 0.0
+
+
+def test_decay_reduces_confidence_and_increases_forgetting():
+    node = NodeState(node_type="belief", confidence=1.0)
+
+    # simulate time passing
+    time.sleep(0.05)
+
+    old_confidence = node.confidence
+    old_forgetting = node.forgetting_score
+
+    node.decay(decay_rate_per_second=0.1)
+
+    assert node.confidence < old_confidence
+    assert node.forgetting_score > old_forgetting
+    assert 0.0 < node.confidence <= 1.0
+    assert 0.0 <= node.forgetting_score < 1.0
+
+
+def test_forgetting_score_matches_confidence():
+    node = NodeState(node_type="belief", confidence=0.75)
+    assert math.isclose(node.forgetting_score, 0.25, rel_tol=1e-6)
+
+
+def test_persistent_node_never_decays():
+    node = NodeState(
+        node_type="core-strategy",
+        confidence=1.0,
+        persistent=True,
+    )
+
+    time.sleep(0.1)
+    node.decay(decay_rate_per_second=1.0)
+
+    assert node.confidence == 1.0
+    assert node.forgetting_score == math.inf
+
+
+def test_multiple_decays_accumulate():
+    node = NodeState(node_type="belief", confidence=1.0)
+
+    time.sleep(0.05)
+    node.decay(decay_rate_per_second=0.1)
+    first_confidence = node.confidence
+
+    time.sleep(0.05)
+    node.decay(decay_rate_per_second=0.1)
+
+    assert node.confidence < first_confidence
+    assert node.forgetting_score > 0.0
+
+
+def test_confidence_clamped_for_forgetting_score():
+    node = NodeState(node_type="belief", confidence=2.0)
+    assert node.forgetting_score == 0.0
+
+    node.confidence = -1.0
+    node.forgetting_score = node._compute_forgetting_score()
+    assert node.forgetting_score == 1.0


### PR DESCRIPTION
This PR introduces a NodeState abstraction for Dialograph, enabling time-aware memory dynamics required for proactive dialogue systems.
Contributes to #1 

Key changes:

- [x] Implemented time-based exponential confidence decay tied to real elapsed time.
- [x] Added an explicit forgetting score derived from confidence for use in traversal and scoring.
- [x] Introduced persistent nodes that never decay or forget (e.g., core beliefs or strategies).
- [x] Ensured internal consistency by synchronizing confidence and forgetting score updates.
- [x] Added pytest-based unit tests covering decay behavior, forgetting dynamics, persistence, and numerical stability.
- [x] These changes establish the foundation for temporal memory modeling and future traversal, scoring, and strategy modules.